### PR TITLE
Deprecated module as it's deprecated in favor of Email::Sender, as the POD suggests.

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -4,6 +4,7 @@ license = Perl_5
 copyright_holder = Casey West
 copyright_year   = 2004
 
+[Deprecated]
 [@Basic]
 [VersionFromModule]
 [MetaConfig]


### PR DESCRIPTION
The `Wait! Achtung!` section of Email::Send POD says that this module is essentially deprecated. Added a line in the dist.ini to add the correct meta data on build.
